### PR TITLE
Potential fix for code scanning alert no. 27: Uncontrolled command line

### DIFF
--- a/src/mcp/core/tool-executor.js
+++ b/src/mcp/core/tool-executor.js
@@ -144,7 +144,7 @@ export class MCPToolExecutor {
    * @returns {Promise<any>} Command result
    */
   async executeClaudeCommand(command, args) {
-    const { execSync } = await import('child_process');
+    const { execFileSync } = await import('child_process');
     
     try {
       // Build command line arguments
@@ -167,10 +167,10 @@ export class MCPToolExecutor {
           break;
         case 'hive-mind':
           if (args.subcommand) cmdArgs.push(args.subcommand);
-          if (args.objective) cmdArgs.push(`"${args.objective}"`);
+          if (args.objective) cmdArgs.push(args.objective);
           break;
         case 'swarm':
-          if (args.objective) cmdArgs.push(`"${args.objective}"`);
+          if (args.objective) cmdArgs.push(args.objective);
           if (args.topology) cmdArgs.push('--topology', args.topology);
           if (args.maxAgents) cmdArgs.push('--max-agents', args.maxAgents.toString());
           break;
@@ -181,12 +181,12 @@ export class MCPToolExecutor {
           break;
         case 'task':
           if (args.action) cmdArgs.push(args.action);
-          if (args.description) cmdArgs.push(`"${args.description}"`);
+          if (args.description) cmdArgs.push(args.description);
           if (args.taskId) cmdArgs.push(args.taskId);
           break;
         case 'memory':
           if (args.action) cmdArgs.push(args.action);
-          if (args.query) cmdArgs.push(`"${args.query}"`);
+          if (args.query) cmdArgs.push(args.query);
           if (args.namespace) cmdArgs.push('--namespace', args.namespace);
           break;
         case 'github':
@@ -196,15 +196,15 @@ export class MCPToolExecutor {
         case 'hooks':
           if (args.hook) cmdArgs.push(args.hook);
           if (args.file) cmdArgs.push('--file', args.file);
-          if (args.command) cmdArgs.push('--command', `"${args.command}"`);
+          if (args.command) cmdArgs.push('--command', args.command);
           break;
       }
       
-      // Execute claude-zen command
-      const fullCommand = `npx claude-zen ${command} ${cmdArgs.join(' ')}`.trim();
-      console.error(`[${new Date().toISOString()}] INFO [Tool-Executor] Executing: ${fullCommand}`);
+      // Execute claude-zen command using execFileSync for safety
+      const execArgs = ['claude-zen', command, ...cmdArgs];
+      console.error(`[${new Date().toISOString()}] INFO [Tool-Executor] Executing: npx ${execArgs.map(a => JSON.stringify(a)).join(' ')}`);
       
-      const output = execSync(fullCommand, { 
+      const output = execFileSync('npx', execArgs, { 
         encoding: 'utf8',
         timeout: 30000, // 30 second timeout
         maxBuffer: 1024 * 1024 // 1MB buffer
@@ -212,7 +212,7 @@ export class MCPToolExecutor {
       
       return {
         success: true,
-        command: fullCommand,
+        command: `npx ${execArgs.map(a => JSON.stringify(a)).join(' ')}`,
         output: output.trim(),
         timestamp: new Date().toISOString()
       };


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/mikkihugo/claude-code-zen/security/code-scanning/27](https://github.com/mikkihugo/claude-code-zen/security/code-scanning/27)

To fix this vulnerability, we should avoid constructing a shell command string and passing it to `execSync`. Instead, we should use `execFileSync` (or `spawnSync`) from the `child_process` module, which allows us to specify the command and its arguments as an array. This approach bypasses the shell and prevents command injection, as arguments are not interpreted by the shell.

Specifically, in `executeClaudeCommand`, instead of building `fullCommand` as a string and passing it to `execSync`, we should build an array of arguments (`cmdArgs`), prepend the subcommand (e.g., `init`, `status`, etc.), and call `execFileSync('npx', ['claude-zen', ...])`. We should also remove any unnecessary quoting of arguments (e.g., `'"' + args.objective + '"'`), as this is not needed when passing arguments as an array.

**Required changes:**
- In `executeClaudeCommand`, replace the construction of `fullCommand` and the call to `execSync(fullCommand, ...)` with a call to `execFileSync('npx', ['claude-zen', command, ...cmdArgs], ...)`.
- Remove any manual quoting of arguments (e.g., `'"' + args.objective + '"'` → just `args.objective`).
- Update logging to show the command and arguments array.
- Import `execFileSync` instead of (or in addition to) `execSync`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `execSync` with `execFileSync` to prevent command injection

- Remove manual quoting of command arguments

- Update logging to display command array format

- Import `execFileSync` instead of `execSync`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["execSync with string command"] --> B["execFileSync with args array"]
  C["Manual argument quoting"] --> D["Direct argument passing"]
  B --> E["Secure command execution"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tool-executor.js</strong><dd><code>Secure command execution implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mcp/core/tool-executor.js

<ul><li>Replace <code>execSync</code> import with <code>execFileSync</code> for secure command execution<br> <li> Remove manual quoting from <code>args.objective</code>, <code>args.description</code>, <br><code>args.query</code>, and <code>args.command</code><br> <li> Change command execution from string concatenation to argument array<br> <li> Update logging to show JSON-quoted arguments for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/mikkihugo/claude-code-zen/pull/39/files#diff-99b306843ad7289a2a7483d600c16991cec596738fd88f0e9046fd51805a2295">+11/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

